### PR TITLE
Croniter v3.2.7 does not exist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ billiard==3.5.0.5
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
-croniter==0.3.27
+croniter==0.3.29
 Django==2.1.7
 django-crispy-forms==1.7.2
 django-tinymce==2.8.0


### PR DESCRIPTION
When installing, pip told me that the listed version of croniter could not be found.